### PR TITLE
✨Feat: Frontend fullscreen canvas option

### DIFF
--- a/src/components/MCBench.tsx
+++ b/src/components/MCBench.tsx
@@ -1,5 +1,5 @@
 import * as THREE from 'three'
-import { useState, Suspense } from 'react'
+import { useState, Suspense, useRef } from 'react'
 import { Share2, Flag, Maximize2 } from 'lucide-react'
 import { Canvas } from '@react-three/fiber'
 import { Environment, OrbitControls, useGLTF } from '@react-three/drei'
@@ -22,6 +22,7 @@ const Model = ({ path }: ModelProps) => {
 
 const MCBench = () => {
   const [voted, setVoted] = useState(false)
+  const viewerRef = useRef<HTMLDivElement>(null)
 
   const buildPair = {
     prompt: 'Build a house',
@@ -49,6 +50,15 @@ const MCBench = () => {
     setVoted(true)
   }
 
+  const handleFullscreen = () => {
+    if (!viewerRef.current) return
+    if (document.fullscreenElement) {
+      document.exitFullscreen()
+    } else {
+      viewerRef.current.requestFullscreen()
+    }
+  }
+
   return (
     <div className="max-w-6xl mx-auto p-4 space-y-6">
       <div className="text-center space-y-2">
@@ -74,10 +84,14 @@ const MCBench = () => {
           {[buildPair.model_a, buildPair.model_b].map((model, idx) => (
             <div
               key={idx}
+              ref={viewerRef}
               className="relative h-[400px] overflow-hidden bg-green-50 rounded-lg"
             >
               <div className="absolute top-2 right-2 z-10">
-                <button className="bg-black/75 text-white p-2 rounded-md w-8 h-8 flex items-center justify-center hover:bg-black/90">
+                <button
+                  onClick={handleFullscreen}
+                  className="bg-black/75 text-white p-2 rounded-md w-8 h-8 flex items-center justify-center hover:bg-black/90"
+                >
                   <Maximize2 className="h-4 w-4" />
                 </button>
               </div>

--- a/src/components/MCBench.tsx
+++ b/src/components/MCBench.tsx
@@ -22,7 +22,8 @@ const Model = ({ path }: ModelProps) => {
 
 const MCBench = () => {
   const [voted, setVoted] = useState(false)
-  const viewerRef = useRef<HTMLDivElement>(null)
+  const viewerRefA = useRef<HTMLDivElement>(null)
+  const viewerRefB = useRef<HTMLDivElement>(null)
 
   const buildPair = {
     prompt: 'Build a house',
@@ -50,12 +51,12 @@ const MCBench = () => {
     setVoted(true)
   }
 
-  const handleFullscreen = () => {
-    if (!viewerRef.current) return
+  const handleFullscreen = (ref: React.RefObject<HTMLDivElement>) => {
+    if (!ref.current) return
     if (document.fullscreenElement) {
       document.exitFullscreen()
     } else {
-      viewerRef.current.requestFullscreen()
+      ref.current.requestFullscreen()
     }
   }
 
@@ -84,12 +85,12 @@ const MCBench = () => {
           {[buildPair.model_a, buildPair.model_b].map((model, idx) => (
             <div
               key={idx}
-              ref={viewerRef}
+              ref={idx === 0 ? viewerRefA : viewerRefB}
               className="relative h-[400px] overflow-hidden bg-green-50 rounded-lg"
             >
               <div className="absolute top-2 right-2 z-10">
                 <button
-                  onClick={handleFullscreen}
+                  onClick={() => handleFullscreen(idx === 0 ? viewerRefA : viewerRefB)}
                   className="bg-black/75 text-white p-2 rounded-md w-8 h-8 flex items-center justify-center hover:bg-black/90"
                 >
                   <Maximize2 className="h-4 w-4" />

--- a/src/components/MCBench.tsx
+++ b/src/components/MCBench.tsx
@@ -1,6 +1,6 @@
 import * as THREE from 'three'
 import { useState, Suspense } from 'react'
-import { Share2, Flag } from 'lucide-react'
+import { Share2, Flag, Maximize2 } from 'lucide-react'
 import { Canvas } from '@react-three/fiber'
 import { Environment, OrbitControls, useGLTF } from '@react-three/drei'
 import Background from './background'
@@ -77,6 +77,11 @@ const MCBench = () => {
               className="relative h-[400px] overflow-hidden bg-green-50 rounded-lg"
             >
               <div className="absolute top-2 right-2 z-10">
+                <button className="bg-black/75 text-white p-2 rounded-md w-8 h-8 flex items-center justify-center hover:bg-black/90">
+                  <Maximize2 className="h-4 w-4" />
+                </button>
+              </div>
+              <div className="absolute bottom-2 left-2 z-10">
                 <div className="bg-black/75 text-white px-2 py-2 rounded-md text-sm w-8 h-8 flex items-center justify-center">
                   {idx === 0 ? 'A' : 'B'}
                 </div>

--- a/src/components/MCBench.tsx
+++ b/src/components/MCBench.tsx
@@ -24,6 +24,8 @@ const MCBench = () => {
   const [voted, setVoted] = useState(false)
   const viewerRefA = useRef<HTMLDivElement>(null)
   const viewerRefB = useRef<HTMLDivElement>(null)
+  const dimensionsRefA = useRef<{ width: number; height: number }>()
+  const dimensionsRefB = useRef<{ width: number; height: number }>()
 
   const buildPair = {
     prompt: 'Build a house',
@@ -51,11 +53,24 @@ const MCBench = () => {
     setVoted(true)
   }
 
-  const handleFullscreen = (ref: React.RefObject<HTMLDivElement>) => {
+  const handleFullscreen = (
+    ref: React.RefObject<HTMLDivElement>,
+    dimensionsRef: React.MutableRefObject<{ width: number; height: number } | undefined>
+  ) => {
     if (!ref.current) return
+
     if (document.fullscreenElement) {
-      document.exitFullscreen()
+      document.exitFullscreen().then(() => {
+        if (ref.current && dimensionsRef.current) {
+          ref.current.style.width = `${dimensionsRef.current.width}px`
+          ref.current.style.height = `${dimensionsRef.current.height}px`
+        }
+      })
     } else {
+      dimensionsRef.current = {
+        width: ref.current.offsetWidth,
+        height: ref.current.offsetHeight
+      }
       ref.current.requestFullscreen()
     }
   }
@@ -86,11 +101,14 @@ const MCBench = () => {
             <div
               key={idx}
               ref={idx === 0 ? viewerRefA : viewerRefB}
-              className="relative h-[400px] overflow-hidden bg-green-50 rounded-lg"
+              className="relative w-full md:flex-1 h-[400px] overflow-hidden bg-green-50 rounded-lg"
             >
               <div className="absolute top-2 right-2 z-10">
                 <button
-                  onClick={() => handleFullscreen(idx === 0 ? viewerRefA : viewerRefB)}
+                  onClick={() => handleFullscreen(
+                    idx === 0 ? viewerRefA : viewerRefB,
+                    idx === 0 ? dimensionsRefA : dimensionsRefB
+                  )}
                   className="bg-black/75 text-white p-2 rounded-md w-8 h-8 flex items-center justify-center hover:bg-black/90"
                 >
                   <Maximize2 className="h-4 w-4" />


### PR DESCRIPTION
This also works on mobile (at least in a browser).
The A/B button locations were moved to position the fullscreen button further away from the vote button.
Had some issues storing the layout size of the canvas after exiting full screen, but the fix I implemented seems to be working fine.