### PR TITLE
🐛 Fix: prevent auth state flash on page refresh

### DIFF
--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -146,6 +146,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }
   }, [token, logout, loginInProgress])
 
+  if (isLoading) {
+    return null; // or return a loading spinner
+  }
+
   return (
     <AuthContext.Provider
       value={{


### PR DESCRIPTION
If you spam refresh when logged in you'll find that the header ui will quickly flash between "Login" --> "Logged in"
This has to do with the flow of operations in AuthProvider.tsx
Below is a quick and simple fix.