### PR TITLE
🐛 Fix: redir /login when authenticated

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -15,10 +15,16 @@ interface OAuthResponse {
 
 export const Login = () => {
   const navigate = useNavigate()
-  const { login } = useAuth()
+  const { login, isAuthenticated } = useAuth()
   const [processedCode, setProcessedCode] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigate('/', { replace: true })
+    }
+  }, [isAuthenticated, navigate])
 
   useEffect(() => {
     const queryString = window.location.search


### PR DESCRIPTION
This pr introduces one change
- If an authenticated users navigates back to /login, we will now redirect them to the home page 