### PR TITLE
add missing URL to .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,4 +2,5 @@ export VITE_ADMIN_API_URL="http://localhost:8001"
 export VITE_API_URL="http://localhost:8000"
 export VITE_GITHUB_CLIENT_ID="{ GITHUB OAUTH CLIENT ID }"
 export VITE_IS_PROD="false"
-export VITE_OBJECT_CDN_ROOT_URL=http://localhost:9000
+export VITE_OBJECT_CDN_ROOT_URL="http://localhost:9000"
+export VITE_EXTERNAL_OBJECT_CDN_ROOT_URL="http://localhost:9000"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ cd mc-bench-frontend
 cp .env.template .env
 bun install
 ```
-Be sure to copy over the Github Client ID from the pre-requisites into your new .env file
+Make sure to copy over the Github Client ID from the pre-requisites into your new .env file
 
 4. Start the services:
 ```bash


### PR DESCRIPTION
add export VITE_EXTERNAL_OBJECT_CDN_ROOT_URL="http://localhost:9000"